### PR TITLE
Add option to have all cards under a parent to keep hierarchy clean

### DIFF
--- a/Assets/CardHouse/CardHouseCore/Scripts/Setup/DeckSetup.cs
+++ b/Assets/CardHouse/CardHouseCore/Scripts/Setup/DeckSetup.cs
@@ -10,6 +10,9 @@ namespace CardHouse
         public GameObject CardPrefab;
         public DeckDefinition DeckDefinition;
         public CardGroup Deck;
+        [SerializeField]
+        [Tooltip("Group all cards under what parent object")]
+        private Transform _deckParent;
         public List<TimedEvent> OnSetupCompleteEventChain;
 
         void Start()
@@ -30,7 +33,15 @@ namespace CardHouse
             var newCardList = new List<Card>();
             foreach (var cardDef in DeckDefinition.CardCollection)
             {
-                var newThing = Instantiate(CardPrefab, Deck.transform.position, Deck.transform.rotation);
+                GameObject newThing;
+                if (_deckParent != null)
+                {
+                    newThing = Instantiate(CardPrefab, Deck.transform.position, Deck.transform.rotation, _deckParent.transform);
+                }
+                else
+                {
+                    newThing = Instantiate(CardPrefab, Deck.transform.position, Deck.transform.rotation);
+                }
                 newCardList.Add(newThing.GetComponent<Card>());
                 var card = newThing.GetComponent<CardSetup>();
 


### PR DESCRIPTION
Cards can be optionally collected into a user defined parent to keep the hierarchy clean.

From this...
![CurrentHierarchy](https://github.com/pipeworks-studios/CardHouse/assets/23315158/8c018e7d-4ab3-438e-b942-dbbf910abdc3)

...to this...
![CleanHierarchy](https://github.com/pipeworks-studios/CardHouse/assets/23315158/486de223-e03a-45c6-b3ed-9649c74281b2)
